### PR TITLE
Update initApi.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibrokethat/cmd-server",
   "description": "nodejs application server, easily expose functionality over any protocol",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "author": {
     "name": "Simon Jefford",
     "email": "si@ibrokethat.com"

--- a/src/lib/bind/toHttp/initApi.js
+++ b/src/lib/bind/toHttp/initApi.js
@@ -209,7 +209,7 @@ module.exports = curry(function initApi(app, handlers, cfg, apiConf) {
                     process.emit('cmd-server:log', logMsg);
                 }).catch(function (err) {
 
-                    if (ctx.proxy) {
+                    if (ctx.proxy && !(err instanceof e.BlockedError)) {
 
                         return err;
                     }


### PR DESCRIPTION
Fix for BlockedError exceptions used by forced upgrade. These were being swallowed instead of returning 423 to the client.